### PR TITLE
Add implementation.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "gulp"
+}

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,3 @@
+{
+  "preset": "gulp"
+}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+language: node_js
+node_js:
+  - '10'
+  - '8'
+  - '6'
+  - '4'
+after_script:
+  - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
-# include-content
-Gulp plugin for loading sourcesContent of a sourcemap.
+# @gulp-sourcemaps/sources-content
+
+[![NPM version][npm-image]][npm-url] [![Downloads][downloads-image]][npm-url] [![Build Status][travis-image]][travis-url] [![AppVeyor Build Status][appveyor-image]][appveyor-url] [![Coveralls Status][coveralls-image]][coveralls-url]
+
+Gulp plugin for loading or clearing sources content of a sourcemap.
+
+## Example
+
+Sources content is loaded by default during `sourcemaps.write()` but this may
+be too late.  This module allows sources content to be loaded before using
+`@gulp-sourcemaps/map-sources` to rewrite using URL's that might not be valid
+on the filesystem.
+
+```js
+var mapSources = require('@gulp-sourcemaps/map-sources');
+var sourcesContent = require('@gulp-sourcemaps/sources-content');
+
+gulp.src(...)
+  .pipe(sourcemaps.init())
+  .pipe(sourcesContent())
+  .pipe(mapSources(function(sourcePath, file) {
+    return '../' + sourcePath;
+  }))
+  .pipe(sourcemaps.write())
+  .pipe(gulp.dest(...))
+```
+
+## API
+
+### `sourcesContent(options)`
+
+Takes a object containing options for this plugin.
+
+#### `options.clear`
+
+Seting this option `true` will cause the sources content to be deleted instead
+of initialized.
+
+## License
+
+MIT
+
+[downloads-image]: http://img.shields.io/npm/dm/@gulp-sourcemaps/sources-content.svg
+[npm-url]: https://npmjs.org/package/@gulp-sourcemaps/sources-content
+[npm-image]: http://img.shields.io/npm/v/@gulp-sourcemaps/sources-content.svg
+
+[travis-url]: https://travis-ci.org/gulp-sourcemaps/sources-content
+[travis-image]: http://img.shields.io/travis/gulp-sourcemaps/sources-content.svg?label=travis-ci
+
+[appveyor-url]: https://ci.appveyor.com/project/phated/sources-content
+[appveyor-image]: https://img.shields.io/appveyor/ci/phated/sources-content.svg?label=appveyor
+
+[coveralls-url]: https://coveralls.io/r/gulp-sourcemaps/sources-content
+[coveralls-image]: http://img.shields.io/coveralls/gulp-sourcemaps/sources-content.svg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+# http://www.appveyor.com/docs/appveyor-yml
+# http://www.appveyor.com/docs/lang/nodejs-iojs
+
+environment:
+  matrix:
+    # node.js
+    - nodejs_version: "4"
+    - nodejs_version: "6"
+    - nodejs_version: "8"
+    - nodejs_version: "10"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+test_script:
+  - node --version
+  - npm --version
+  - cmd: npm test
+
+build: off
+
+# build version format
+version: "{build}"

--- a/index.js
+++ b/index.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+var through = require('through2');
+var stripBom = require('strip-bom-string');
+
+function sourcesContent(options) {
+  if (!options) {
+    options = {};
+  }
+
+  function transform(file, _, cb) {
+    var sourceMap = file.sourceMap;
+    if (!sourceMap) {
+      return cb(null, file);
+    }
+
+    if (options.clear) {
+      delete sourceMap.sourcesContent;
+
+      return cb(null, file);
+    }
+
+    if (!sourceMap.sources) {
+      return cb(null, file);
+    }
+
+    sourceMap.sourcesContent = sourceMap.sourcesContent || [];
+
+    // Load missing source content
+    var remaining = sourceMap.sources.length;
+    function gotOne() {
+      remaining--;
+
+      if (remaining === 0) {
+        cb(null, file);
+      }
+    }
+
+    sourceMap.sources.forEach(function(_, idx) {
+      if (sourceMap.sourcesContent[idx]) {
+        gotOne();
+        return;
+      }
+
+      var sourcePath = path.resolve(file.base, sourceMap.sources[idx]);
+
+      fs.readFile(sourcePath, 'utf8', function(err, data) {
+        sourceMap.sourcesContent[idx] = err ? null : stripBom(data);
+        gotOne();
+      });
+    });
+  }
+
+  return through.obj(transform);
+}
+
+module.exports = sourcesContent;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@gulp-sourcemaps/sources-content",
+  "version": "1.0.0",
+  "description": "Gulp plugin for managing sourcesContent.",
+  "author": "Gulp-sourcemaps Team",
+  "repository": "gulp-sourcemaps/sources-content",
+  "license": "MIT",
+  "engines": {
+    "node": ">= 4"
+  },
+  "main": "index.js",
+  "files": [
+    "LICENSE",
+    "index.js"
+  ],
+  "scripts": {
+    "lint": "eslint . && jscs index.js test/",
+    "pretest": "npm run lint",
+    "test": "mocha --async-only",
+    "cover": "istanbul cover _mocha --report lcovonly",
+    "coveralls": "npm run cover && istanbul-coveralls"
+  },
+  "dependencies": {
+    "strip-bom-string": "^1.0.0",
+    "through2": "^2.0.3"
+  },
+  "devDependencies": {
+    "eslint": "^1.7.3",
+    "eslint-config-gulp": "^2.0.0",
+    "expect": "^1.19.0",
+    "istanbul": "^0.4.3",
+    "istanbul-coveralls": "^1.0.3",
+    "jscs": "^2.3.5",
+    "jscs-preset-gulp": "^1.0.0",
+    "mississippi": "^1.3.0",
+    "mocha": "^2.4.5",
+    "vinyl": "^2.0.1"
+  },
+  "keywords": [
+    "sourcemap",
+    "sources",
+    "stream"
+  ]
+}

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "gulp/test"
+}

--- a/test/assets/helloworld.js
+++ b/test/assets/helloworld.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log('Hello world!');

--- a/test/assets/helloworld2.js
+++ b/test/assets/helloworld2.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log('Hello world 2!');

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,155 @@
+'use strict';
+
+var fs = require('fs');
+var expect = require('expect');
+
+var miss = require('mississippi');
+var File = require('vinyl');
+
+var sourcesContent = require('../');
+
+var pipe = miss.pipe;
+var from = miss.from;
+var concat = miss.concat;
+
+var helloWorld = fs.readFileSync('test/assets/helloworld.js', 'utf8');
+var helloWorld2 = fs.readFileSync('test/assets/helloworld2.js', 'utf8');
+
+function makeFile() {
+  var file = new File({
+    cwd: __dirname,
+    base: __dirname + '/assets',
+    path: __dirname + '/assets/helloworld.js',
+    contents: null,
+  });
+
+  file.sourceMap = {
+    version: 3,
+    file: 'helloworld.js',
+    names: [],
+    mappings: '',
+    sources: ['helloworld.js', 'helloworld2.js'],
+  };
+
+  return file;
+}
+
+function runTest(files, assert, done, opts) {
+  pipe([
+    from.obj(files),
+    sourcesContent(opts),
+    concat(assert),
+  ], done);
+}
+
+function checkMap(sourceMap, src1) {
+  if (!src1) {
+    src1 = helloWorld;
+  }
+  expect(sourceMap.sourcesContent.length).toEqual(2);
+  expect(sourceMap.sourcesContent[0]).toEqual(src1);
+  expect(sourceMap.sourcesContent[1]).toEqual(helloWorld2);
+}
+
+describe('sourcesContent', function() {
+  it('loads sourcesContent', function(done) {
+    function assert(files) {
+      expect(files.length).toEqual(1);
+      checkMap(files[0].sourceMap);
+    }
+
+    runTest([makeFile()], assert, done);
+  });
+
+  it('ignores a file without sourceMap property', function(done) {
+    var file = makeFile();
+    delete file.sourceMap;
+
+    function assert(files) {
+      expect(files.length).toEqual(1);
+      expect(typeof files[0].sourceMap).toEqual('undefined');
+    }
+
+    runTest([file], assert, done);
+  });
+
+  it('ignores a file without sourceMap.sources property', function(done) {
+    var file = makeFile();
+    delete file.sourceMap.sources;
+
+    function assert(files) {
+      expect(files.length).toEqual(1);
+      expect(typeof files[0].sourceMap.sources).toEqual('undefined');
+      expect(typeof files[0].sourceMap.sourcesContent).toEqual('undefined');
+    }
+
+    runTest([file], assert, done);
+  });
+
+  it('sets null sourcesContent for file not found', function(done) {
+    var file = makeFile();
+    file.sourceMap.sources = ['file-not-found.js'];
+
+    function assert(files) {
+      expect(files.length).toEqual(1);
+      expect(files[0].sourceMap.sourcesContent.length).toEqual(1);
+      expect(files[0].sourceMap.sourcesContent[0]).toEqual(null);
+    }
+
+    runTest([file], assert, done);
+  });
+
+  it('doesn\'t overwrite existing sourcesContent entries', function(done) {
+    var file = makeFile();
+    var existingContent = '/**/';
+    file.sourceMap.sourcesContent = [existingContent];
+
+    function assert(files) {
+      expect(files.length).toEqual(1);
+      checkMap(files[0].sourceMap, existingContent);
+    }
+
+    runTest([file], assert, done);
+  });
+
+  it('clear deletes sourcesContent but not sources', function(done) {
+    var file = makeFile();
+    file.sourceMap.sourcesContent = ['/**/', '/**/'];
+
+    function assert(files) {
+      expect(files.length).toEqual(1);
+      expect(typeof files[0].sourceMap).toEqual('object');
+      expect(files[0].sourceMap.sources.length).toEqual(2);
+      expect(typeof files[0].sourceMap.sourcesContent).toEqual('undefined');
+    }
+
+    runTest([file], assert, done, { clear: true });
+  });
+
+  it('clear deletes sourcesContent even with no sources', function(done) {
+    var file = makeFile();
+    file.sourceMap.sourcesContent = ['/**/', '/**/'];
+    delete file.sourceMap.sources;
+
+    function assert(files) {
+      expect(files.length).toEqual(1);
+      expect(typeof files[0].sourceMap).toEqual('object');
+      expect(typeof files[0].sourceMap.sources).toEqual('undefined');
+      expect(typeof files[0].sourceMap.sourcesContent).toEqual('undefined');
+    }
+
+    runTest([file], assert, done, { clear: true });
+  });
+
+  it('clear ignores a file without sourceMap property', function(done) {
+    var file = makeFile();
+    delete file.sourceMap;
+
+    function assert(files) {
+      expect(files.length).toEqual(1);
+      expect(typeof files[0].sourceMap).toEqual('undefined');
+    }
+
+    runTest([file], assert, done, { clear: true });
+  });
+});


### PR DESCRIPTION
This implements, tests and documents this module.  If you don't like the API decision I made I can change it so this module exports a `.load` and `.remove`, personally I think an off by default option for clearing the existing sourcesContent makes sense.  I found myself here because I need to `mapSources` to paths that are valid from the web but do not exist on the filesystem, this caused `gulpSourcemaps.write` to load sourcesContent with a bunch of `null` values.  I've already verified that using this module before `mapSources` produces a correct/complete sourcemap without modifying gulp-sourcemap as long as the `includeContent` option doesn't conflict.

Fixes #1, Fixes #2 
