### PR TITLE
feat: Accept function for the `clear` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ Takes a object containing options for this plugin.
 Seting this option `true` will cause the sources content to be deleted instead
 of initialized.
 
+A function can be passed for clear, this allows removing sources content associated
+with some files but not others.  The function is called with `filename` argument for
+each source, returning `true` causes the contents for that file to be cleared.
+
+```js
+gulp.src(...)
+  /* ... */
+  .pipe(sourcesContent({
+    clear: function(filename, mainFile) {
+      /* Clear all sourceContent elements except the one
+       * associated with sourceMap.file. */
+      return filename !== mainFile
+    }
+  }))
+  .pipe(gulp.dest(...))
+```
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -18,7 +18,21 @@ function sourcesContent(options) {
     }
 
     if (options.clear) {
-      delete sourceMap.sourcesContent;
+      var allClear = true;
+      if (typeof options.clear === 'function' && sourceMap.sources
+          && sourceMap.sourcesContent) {
+        sourceMap.sources.forEach(function(filename, idx) {
+          if (options.clear(filename, sourceMap.file)) {
+            sourceMap.sourcesContent[idx] = null;
+          } else {
+            allClear = false;
+          }
+        });
+      }
+
+      if (allClear) {
+        delete sourceMap.sourcesContent;
+      }
 
       return cb(null, file);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -141,6 +141,60 @@ describe('sourcesContent', function() {
     runTest([file], assert, done, { clear: true });
   });
 
+  it('clear function sets sourcesContent elements null but not sources', function(done) {
+    var file = makeFile();
+    file.sourceMap.sourcesContent = [helloWorld, helloWorld2];
+
+    function assert(files) {
+      expect(files.length).toEqual(1);
+      expect(typeof files[0].sourceMap).toEqual('object');
+      expect(files[0].sourceMap.sources.length).toEqual(2);
+      expect(files[0].sourceMap.sourcesContent.length).toEqual(2);
+      expect(files[0].sourceMap.sourcesContent[0]).toEqual(helloWorld);
+      expect(files[0].sourceMap.sourcesContent[1]).toEqual(null);
+    }
+
+    function clear(filename, mainFile) {
+      expect(mainFile).toEqual(file.sourceMap.file);
+      return filename !== mainFile;
+    }
+
+    runTest([file], assert, done, { clear: clear });
+  });
+
+  it('always true clear function deletes sourcesContent but not sources', function(done) {
+    var file = makeFile();
+    file.sourceMap.sourcesContent = [helloWorld, helloWorld2];
+
+    function assert(files) {
+      expect(files.length).toEqual(1);
+      expect(typeof files[0].sourceMap).toEqual('object');
+      expect(files[0].sourceMap.sources.length).toEqual(2);
+      expect(typeof files[0].sourceMap.sourcesContent).toEqual('undefined');
+    }
+
+    function clear() {
+      return true;
+    }
+
+    runTest([file], assert, done, { clear: clear });
+  });
+
+  it('clear deletes sourcesContent even with no sources', function(done) {
+    var file = makeFile();
+    file.sourceMap.sourcesContent = ['/**/', '/**/'];
+    delete file.sourceMap.sources;
+
+    function assert(files) {
+      expect(files.length).toEqual(1);
+      expect(typeof files[0].sourceMap).toEqual('object');
+      expect(typeof files[0].sourceMap.sources).toEqual('undefined');
+      expect(typeof files[0].sourceMap.sourcesContent).toEqual('undefined');
+    }
+
+    runTest([file], assert, done, { clear: true });
+  });
+
   it('clear ignores a file without sourceMap property', function(done) {
     var file = makeFile();
     delete file.sourceMap;


### PR DESCRIPTION
This allows conditional removal of sourcesContent entries based on
associated filename.

---

This is useful for bundles created for web pages.  It can be desirable for the entry-point to be the same filename before/after bundling.  So you have `src/index.html` importing `src/index.js` which imports a bunch of other sources.  You copy `src/index.html` to `build/index.html`, but `build/index.js` is the bundle, not the source.  All other files which became part of the bundle are copied to the appropriate place within `build/` so browsers can find them via `sourceMap.sources`, but `src/index.js` needs to be in the source map.

Note for my own purposes a way to say "clear all sourcesContent which are not associated with sourceMap.file" would be good enough but I figured this callback would be more generic.